### PR TITLE
Fix MeasureSize

### DIFF
--- a/lib/src/measure_size.dart
+++ b/lib/src/measure_size.dart
@@ -30,6 +30,7 @@ class _SizeRenderObject extends RenderProxyBox {
   @override
   void performLayout() {
     super.performLayout();
+    if (child == null) return;
     final Size newSize = child?.size ?? Size.zero;
     if (_oldSize == newSize) return;
     _oldSize = newSize;

--- a/lib/src/widget.dart
+++ b/lib/src/widget.dart
@@ -188,7 +188,11 @@ class _CustomSlidingSegmentedControlState<T> extends State<CustomSlidingSegmente
     }
   }
 
-  void calculateSize({required Size size, required MapEntry<T?, Widget> item, required bool isCacheEnabled}) {
+  void calculateSize({
+    required Size size,
+    required MapEntry<T?, Widget> item,
+    required bool isCacheEnabled,
+  }) {
     height ??= size.height;
     final Map<T?, double> _temp = {};
     _temp.putIfAbsent(item.key, () => widget.fixedWidth ?? size.width);
@@ -345,20 +349,24 @@ class _CustomSlidingSegmentedControlState<T> extends State<CustomSlidingSegmente
             decoration: widget.thumbDecoration,
           ),
           Row(
-            children: [
-              for (final item in widget.children.entries) ...[
-                MeasureSize(
-                  onChange: (value) {
-                    calculateSize(
-                      size: value,
-                      item: item,
-                      isCacheEnabled: true,
-                    );
-                  },
-                  child: widget.isStretch ? Expanded(child: _segmentItem(item)) : _segmentItem(item),
-                ),
-              ],
-            ],
+            children: widget.children.entries.map((item) {
+              final measureSize = MeasureSize(
+                onChange: (value) {
+                  calculateSize(
+                    size: value,
+                    item: item,
+                    isCacheEnabled: true,
+                  );
+                },
+                child: _segmentItem(item),
+              );
+
+              if (widget.isStretch) {
+                return Expanded(child: measureSize);
+              }
+
+              return measureSize;
+            }).toList(growable: false),
           ),
         ],
       ),


### PR DESCRIPTION
I fixed work of `MeasureSize`, making it more suitable for it purpose. 
Generally this widget should notify parent if size of it's child has been changed. But it did not do it if it's `build` method has not been called. It could create bugs such as i attached to this PR. To fix it I rewrite this class to `RenderObject`, now it works as expected
![telegram-cloud-photo-size-2-5323563576746699075-y](https://github.com/hadukin/custom_sliding_segmented_control/assets/17158960/57f50e95-52f6-4021-8add-ab87102073b3)
